### PR TITLE
build: update docker image name to use correct org

### DIFF
--- a/stack.env
+++ b/stack.env
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-STACK_IMG ?= crossplaneio/stack-minimal-gcp:latest
+STACK_IMG ?= crossplane/stack-minimal-gcp:latest
 
 CRD_DIR ?= config/crd/bases
 STACK_PACKAGE_REGISTRY_SOURCE ?= config/stack/manifests


### PR DESCRIPTION
This PR fixes #6 simply by updating the `STACK_IMG` variable in `stack.env` to point to the correct `crossplane` org.

Tested by removing all local images and then running `kubectl crossplane stack build`.