### PR TITLE
fix image path in install.yaml

### DIFF
--- a/config/stack/manifests/install.yaml
+++ b/config/stack/manifests/install.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: "crossplaneio-stack-minimal-gcp-controller"
-        image: "crossplaneio/stack-minimal-gcp:latest"
+        image: "crossplane/stack-minimal-gcp:latest"
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
While https://github.com/crossplaneio/stack-minimal-gcp/pull/7 fixed what tag is added to the produced image, it didn't fix the `install.yaml`, hence controller never comes up due to `ErrImagePull`

Related to https://github.com/crossplaneio/crossplane/issues/1126

Fixes https://github.com/crossplaneio/stack-minimal-gcp/issues/6 and #8 