### PR TITLE
Use forProvider in GCP Connection

### DIFF
--- a/resources/gcp/compute/kustomizeconfig.yaml
+++ b/resources/gcp/compute/kustomizeconfig.yaml
@@ -20,6 +20,10 @@ nameReference:
         kind: Subnetwork
       - path: specTemplate/subnetworkRef/name
         kind: GKEClusterClass
+  - kind: GlobalAddress
+    fieldSpecs:
+      - path: spec/name
+      - kind: GlobalAddress
   - kind: Provider
     fieldSpecs:
       - path: spec/providerRef/name

--- a/resources/gcp/servicenetworking/connection.yaml
+++ b/resources/gcp/servicenetworking/connection.yaml
@@ -3,11 +3,12 @@ kind: Connection
 metadata:
   name: connection
 spec:
-  parent: services/servicenetworking.googleapis.com
-  networkRef:
-    name: network
-  reservedPeeringRangeRefs:
-    - name: globaladdress
+  forProvider:
+    parent: services/servicenetworking.googleapis.com
+    networkRef:
+      name: network
+    reservedPeeringRangeRefs:
+      - name: globaladdress
   reclaimPolicy: Delete
   providerRef:
     name: gcp-provider

--- a/resources/gcp/servicenetworking/kustomizeconfig.yaml
+++ b/resources/gcp/servicenetworking/kustomizeconfig.yaml
@@ -6,11 +6,11 @@
 nameReference:
   - kind: Network
     fieldSpecs:
-      - path: spec/networkRef/name
+      - path: spec/forProvider/networkRef/name
         kind: Connection
   - kind: GlobalAddress
     fieldSpecs:
-      - path: spec/reservedPeeringRangeRefs/name
+      - path: spec/forProvider/reservedPeeringRangeRefs/name
         kind: Connection
   - kind: Provider
     fieldSpecs:


### PR DESCRIPTION
Minor change to make new `v1beta1` `Connection` resource function as expected. Also updates `globaladdress.spec.name` to be prefixed with `MinimalGCP` resource name like other resources.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>