### PR TITLE
Add pipeline builds

### DIFF
--- a/Jenkinsfile.branch
+++ b/Jenkinsfile.branch
@@ -1,0 +1,51 @@
+// The branch pipeline cuts a release branch.
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'branch', defaultValue: '', description: 'Required. The release branch to create. For example: "release-0.0". This should typically be "release-MAJOR.MINOR".')
+        string(name: 'commit', defaultValue: '', description: 'Optional. Commit hash to use as the head of the branch. For example: 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty, the latest commit hash on the current branch will be used.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
+    }
+
+    stages {
+
+        stage('Prepare') {
+            steps {
+                 // github credentials are not setup to push over https in jenkins. add the github token to the url
+                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
+                sh 'git config user.name "upbound-bot"'
+                sh 'git config user.email "info@crossplane.io"'
+                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
+            }
+        }
+
+        stage('Tag Release') {
+            steps {
+                sh "test -n '${params.branch}' || ( echo 'Branch is required - please enter a branch!' && exit 1 )"
+                // If the commit is not passed, it'll be empty, which means git will use the head
+                // of the current branch. Most of the time, the default behavior will be used (from master).
+                //
+                // For the push, we're assuming the remote is named "origin", but this is the convention,
+                // so it's a safe assumption for this situation.
+                sh """git branch ${params.branch} ${params.commit}
+                      git push origin ${params.branch}
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}

--- a/Jenkinsfile.continuous
+++ b/Jenkinsfile.continuous
@@ -1,0 +1,50 @@
+// The continuous pipeline is used to build and publish new versions of the stack when changes are merged into
+// the master branch.
+pipeline {
+    agent { label 'upbound-gce' }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    // Checks for unprocessed changes in the repo once per day
+    // 'H' allows Jenkins to choose the time to balance the load
+    triggers {
+        pollSCM('H H * * *')
+    }
+
+    environment {
+        DOCKER = credentials('dockerhub-upboundci')
+        CROSSPLANE_CLI_RELEASE = 'master'
+    }
+
+    stages {
+        stage('Prepare') {
+            steps {
+                sh 'mkdir bin'
+                sh "curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
+            }
+        }
+        stage('Promote Release') {
+
+            steps {
+                // The build step turns this into a "dirty" environment from the perspective of `git describe`,
+                // so we set the version once at the beginning and use it for both the build and publish steps.
+
+                sh """STACK_VERSION=$( git describe --tags --dirty --always )
+                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
+                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                deleteDir()
+            }
+        }
+    }
+}

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -1,0 +1,48 @@
+// The publish pipeline is used to publish a single tagged image version of the stack.
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are publishing. For example: v0.4.0. If left unspecified, the build will generate one for you.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        DOCKER = credentials('dockerhub-upboundci')
+        CROSSPLANE_CLI_RELEASE = 'master'
+    }
+
+    stages {
+        stage('Prepare') {
+            steps {
+                sh 'mkdir bin'
+                sh "curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
+            }
+        }
+        stage('Promote Release') {
+
+            steps {
+                // The build step turns this into a "dirty" environment from the perspective of `git describe`,
+                // so we set the version once at the beginning and use it for both the build and publish steps.
+
+                sh """STACK_VERSION=${params.version}
+                      STACK_VERSION=\${STACK_VERSION:-\$( git describe --tags --dirty --always )}
+                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
+                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                deleteDir()
+            }
+        }
+    }
+}

--- a/Jenkinsfile.tag
+++ b/Jenkinsfile.tag
@@ -1,0 +1,54 @@
+// The tag pipeline tags a git commit and pushes it to the origin repo.
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are tagging. For example: v0.4.0. If left unspecified, the build will generate one for you.')
+        string(name: 'commit', defaultValue: '', description: 'Optional commit hash to tag. For example: 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty, the latest commit hash will be used.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
+    }
+
+    stages {
+
+        stage('Prepare') {
+            steps {
+                 // github credentials are not setup to push over https in jenkins. add the github token to the url
+                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
+                sh 'git config user.name "upbound-bot"'
+                sh 'git config user.email "info@crossplane.io"'
+                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
+            }
+        }
+
+        stage('Tag Release') {
+            steps {
+                // The first few lines set the version - it uses the passed version, or
+                // generates one.
+                // If the commit is not passed, it'll be empty, which means git will tag the head
+                // of the current branch. Most of the time, the default behavior will be used.
+                //
+                // For the push, we're assuming the remote is named "origin", but this is the convention,
+                // so it's a safe assumption for this situation.
+                sh """VERSION='${params.version}'
+                      VERSION=\${VERSION:-\$( git describe --tags --dirty --always )}
+                      git tag -f -m "release \${VERSION}" \${VERSION} ${params.commit}
+                      git push origin \${VERSION}
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-IMG ?= "crossplane/stack-minimal-gcp"
-VERSION ?= "0.2.1"
+STACK_VERSION ?= 0.2.1
+STACK_IMG ?= crossplane/stack-minimal-gcp:$(STACK_VERSION)
 
 build:
-	docker build . -t ${IMG}:${VERSION}
+	docker build . -t ${STACK_IMG}
+.PHONY: build
+
+publish:
+	docker push ${STACK_IMG}
+.PHONY: publish


### PR DESCRIPTION
Related to https://github.com/crossplane/crossplane/issues/1235

## Overview

This adds pipeline builds for the minimal gcp stack:

* By hand: Cut branch, tag, build+publish
* Automatically: build and publish when changes are merged to master

To make things simpler, this also depends on some changes to the crossplane cli for picking up build steps in a `Makefile`: https://github.com/crossplane/crossplane-cli/pull/41 

## Testing done

I haven't tested these jobs specifically yet, but all of them other than `Jenkinsfile.continuous` have already been tested using the sample-stack-wordpress repo.