### PR TITLE
jenkinsfiles: use shared pipelines

### DIFF
--- a/Jenkinsfile.branch
+++ b/Jenkinsfile.branch
@@ -1,8 +1,8 @@
 // Load a library dynamically. For more detail, see:
 // https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
-library identifier: 'stack-cicd@master', retriever: modernSCM(
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
   [$class: 'GitSCMSource',
-   remote: 'https://github.com/suskin/stack-cicd',
+   remote: 'https://github.com/crossplane/cicd',
    credentialsId: 'github-upbound-jenkins'])
 
 // This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.

--- a/Jenkinsfile.branch
+++ b/Jenkinsfile.branch
@@ -1,51 +1,9 @@
-// The branch pipeline cuts a release branch.
-pipeline {
-    agent { label 'upbound-gce' }
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'stack-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/suskin/stack-cicd',
+   credentialsId: 'github-upbound-jenkins'])
 
-    parameters {
-        string(name: 'branch', defaultValue: '', description: 'Required. The release branch to create. For example: "release-0.0". This should typically be "release-MAJOR.MINOR".')
-        string(name: 'commit', defaultValue: '', description: 'Optional. Commit hash to use as the head of the branch. For example: 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty, the latest commit hash on the current branch will be used.')
-    }
-
-    options {
-        disableConcurrentBuilds()
-        timestamps()
-    }
-
-    environment {
-        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
-    }
-
-    stages {
-
-        stage('Prepare') {
-            steps {
-                 // github credentials are not setup to push over https in jenkins. add the github token to the url
-                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
-                sh 'git config user.name "upbound-bot"'
-                sh 'git config user.email "info@crossplane.io"'
-                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
-            }
-        }
-
-        stage('Tag Release') {
-            steps {
-                sh "test -n '${params.branch}' || ( echo 'Branch is required - please enter a branch!' && exit 1 )"
-                // If the commit is not passed, it'll be empty, which means git will use the head
-                // of the current branch. Most of the time, the default behavior will be used (from master).
-                //
-                // For the push, we're assuming the remote is named "origin", but this is the convention,
-                // so it's a safe assumption for this situation.
-                sh """git branch ${params.branch} ${params.commit}
-                      git push origin ${params.branch}
-                """
-            }
-        }
-    }
-
-    post {
-        always {
-            deleteDir()
-        }
-    }
-}
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+runStackBranchPipeline()

--- a/Jenkinsfile.continuous
+++ b/Jenkinsfile.continuous
@@ -1,50 +1,9 @@
-// The continuous pipeline is used to build and publish new versions of the stack when changes are merged into
-// the master branch.
-pipeline {
-    agent { label 'upbound-gce' }
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'stack-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/suskin/stack-cicd',
+   credentialsId: 'github-upbound-jenkins'])
 
-    options {
-        disableConcurrentBuilds()
-        timestamps()
-    }
-
-    // Checks for unprocessed changes in the repo once per day
-    // 'H' allows Jenkins to choose the time to balance the load
-    triggers {
-        pollSCM('H H * * *')
-    }
-
-    environment {
-        DOCKER = credentials('dockerhub-upboundci')
-        CROSSPLANE_CLI_RELEASE = 'master'
-    }
-
-    stages {
-        stage('Prepare') {
-            steps {
-                sh 'mkdir bin'
-                sh "curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
-            }
-        }
-        stage('Promote Release') {
-
-            steps {
-                // The build step turns this into a "dirty" environment from the perspective of `git describe`,
-                // so we set the version once at the beginning and use it for both the build and publish steps.
-
-                sh """STACK_VERSION=$( git describe --tags --dirty --always )
-                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
-                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
-                """
-            }
-        }
-    }
-
-    post {
-        always {
-            script {
-                deleteDir()
-            }
-        }
-    }
-}
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+runStackContinuousPipeline()

--- a/Jenkinsfile.continuous
+++ b/Jenkinsfile.continuous
@@ -1,8 +1,8 @@
 // Load a library dynamically. For more detail, see:
 // https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
-library identifier: 'stack-cicd@master', retriever: modernSCM(
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
   [$class: 'GitSCMSource',
-   remote: 'https://github.com/suskin/stack-cicd',
+   remote: 'https://github.com/crossplane/cicd',
    credentialsId: 'github-upbound-jenkins'])
 
 // This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -1,8 +1,8 @@
 // Load a library dynamically. For more detail, see:
 // https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
-library identifier: 'stack-cicd@master', retriever: modernSCM(
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
   [$class: 'GitSCMSource',
-   remote: 'https://github.com/suskin/stack-cicd',
+   remote: 'https://github.com/crossplane/cicd',
    credentialsId: 'github-upbound-jenkins'])
 
 // This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -1,48 +1,9 @@
-// The publish pipeline is used to publish a single tagged image version of the stack.
-pipeline {
-    agent { label 'upbound-gce' }
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'stack-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/suskin/stack-cicd',
+   credentialsId: 'github-upbound-jenkins'])
 
-    parameters {
-        string(name: 'version', defaultValue: '', description: 'The version you are publishing. For example: v0.4.0. If left unspecified, the build will generate one for you.')
-    }
-
-    options {
-        disableConcurrentBuilds()
-        timestamps()
-    }
-
-    environment {
-        DOCKER = credentials('dockerhub-upboundci')
-        CROSSPLANE_CLI_RELEASE = 'master'
-    }
-
-    stages {
-        stage('Prepare') {
-            steps {
-                sh 'mkdir bin'
-                sh "curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
-            }
-        }
-        stage('Promote Release') {
-
-            steps {
-                // The build step turns this into a "dirty" environment from the perspective of `git describe`,
-                // so we set the version once at the beginning and use it for both the build and publish steps.
-
-                sh """STACK_VERSION=${params.version}
-                      STACK_VERSION=\${STACK_VERSION:-\$( git describe --tags --dirty --always )}
-                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
-                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
-                """
-            }
-        }
-    }
-
-    post {
-        always {
-            script {
-                deleteDir()
-            }
-        }
-    }
-}
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+runStackPublishPipeline()

--- a/Jenkinsfile.tag
+++ b/Jenkinsfile.tag
@@ -1,54 +1,9 @@
-// The tag pipeline tags a git commit and pushes it to the origin repo.
-pipeline {
-    agent { label 'upbound-gce' }
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'stack-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/suskin/stack-cicd',
+   credentialsId: 'github-upbound-jenkins'])
 
-    parameters {
-        string(name: 'version', defaultValue: '', description: 'The version you are tagging. For example: v0.4.0. If left unspecified, the build will generate one for you.')
-        string(name: 'commit', defaultValue: '', description: 'Optional commit hash to tag. For example: 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty, the latest commit hash will be used.')
-    }
-
-    options {
-        disableConcurrentBuilds()
-        timestamps()
-    }
-
-    environment {
-        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
-    }
-
-    stages {
-
-        stage('Prepare') {
-            steps {
-                 // github credentials are not setup to push over https in jenkins. add the github token to the url
-                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
-                sh 'git config user.name "upbound-bot"'
-                sh 'git config user.email "info@crossplane.io"'
-                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
-            }
-        }
-
-        stage('Tag Release') {
-            steps {
-                // The first few lines set the version - it uses the passed version, or
-                // generates one.
-                // If the commit is not passed, it'll be empty, which means git will tag the head
-                // of the current branch. Most of the time, the default behavior will be used.
-                //
-                // For the push, we're assuming the remote is named "origin", but this is the convention,
-                // so it's a safe assumption for this situation.
-                sh """VERSION='${params.version}'
-                      VERSION=\${VERSION:-\$( git describe --tags --dirty --always )}
-                      git tag -f -m "release \${VERSION}" \${VERSION} ${params.commit}
-                      git push origin \${VERSION}
-                """
-            }
-        }
-    }
-
-    post {
-        always {
-            deleteDir()
-        }
-    }
-}
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+runStackTagPipeline()

--- a/Jenkinsfile.tag
+++ b/Jenkinsfile.tag
@@ -1,8 +1,8 @@
 // Load a library dynamically. For more detail, see:
 // https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
-library identifier: 'stack-cicd@master', retriever: modernSCM(
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
   [$class: 'GitSCMSource',
-   remote: 'https://github.com/suskin/stack-cicd',
+   remote: 'https://github.com/crossplane/cicd',
    credentialsId: 'github-upbound-jenkins'])
 
 // This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.


### PR DESCRIPTION
## Overview

We have several jobs with the same pipeline code, so we want to be able
to reuse code across them. This uses Jenkins dynamic library loading and
execution to share pipeline code. This should make it easier to add and maintain the jobs.

## Testing done

I've tested the loading and executing here: https://jenkinsci.upbound.io/job/crossplane/job/stack-minimal-gcp/job/branch-create/job/test-submodule-build/5/console

## NOTE

Note that this shared code lives in a non-crossplane org repo; we should move it into a shared crossplane repo, but I don't have permissions to create one, so I'm using a separate one for now until that's created.