### PR TITLE
pin down the version of templating-controller

### DIFF
--- a/.registry/behavior.yaml
+++ b/.registry/behavior.yaml
@@ -6,6 +6,7 @@ crd:
   apiVersion: gcp.resourcepacks.crossplane.io/v1alpha1
 engine:
   type: kustomize
+  controllerImage: crossplane/templating-controller:v0.2.1
   kustomize:
     overlays:
       - apiVersion: gcp.crossplane.io/v1alpha3


### PR DESCRIPTION
This is to ensure the tested version of templating-controller gets to reconcile this template stack. This is possible since https://github.com/crossplane/crossplane/pull/1294