### PR TITLE
metadata: remove app.yaml version

### DIFF
--- a/.registry/app.yaml
+++ b/.registry/app.yaml
@@ -2,7 +2,6 @@ title: "Minimal GCP Environment"
 readme: ""
 overview: "This stack provisions a private network and creates resource classes that has minimal node settings and refer to that private network."
 overviewShort: "Start using GCP with Crossplane without needing to create your own resource classes!"
-version: v0.2.2
 maintainers:
   - name: "Muvaffak Onus"
     email: "monus@upbound.io"


### PR DESCRIPTION
## Overview

We have observed that we appear to be treating stack version as having
two sources of truth: the app.yaml, and the docker tag. We plan to move
away from using the version in `app.yaml` as part of making it simpler
to manage the versions for our stacks.

## Testing done

I have tested this locally, and we will need https://github.com/crossplane/crossplane/issues/1307 to be done before we can merge this.