### PR TITLE
Use custom machine tier for Postgres CloudSQL instances

### DIFF
--- a/kustomize/gcp/database/cloudsqlinstanceclass.yaml
+++ b/kustomize/gcp/database/cloudsqlinstanceclass.yaml
@@ -35,7 +35,7 @@ specTemplate:
     databaseVersion: POSTGRES_9_6
     region: $(REGION)
     settings:
-      tier: db-n1-standard-1
+      tier: db-custom-1-3840
       dataDiskType: PD_SSD
       dataDiskSizeGb: 10
       ipConfiguration:


### PR DESCRIPTION
`Postgres` instances will not provision without using a custom machine type.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>