### PR TITLE
Delete Provider resource last

### DIFF
--- a/.registry/behavior.yaml
+++ b/.registry/behavior.yaml
@@ -5,7 +5,7 @@ crd:
   apiVersion: gcp.stacks.crossplane.io/v1alpha1
 engine:
   type: kustomize
-  controllerImage: crossplane/templating-controller:v0.3.0
+  controllerImage: crossplane/templating-controller:v0.3.0-9.gb138971
   kustomize:
     overlays:
       - apiVersion: gcp.crossplane.io/v1alpha3

--- a/kustomize/gcp/provider.yaml
+++ b/kustomize/gcp/provider.yaml
@@ -2,6 +2,8 @@ apiVersion: gcp.crossplane.io/v1alpha3
 kind: Provider
 metadata:
   name: gcp-provider
+  annotations:
+    templatestacks.crossplane.io/deletion-priority: "-1"
 spec:
   credentialsSecretRef:
     key: credentials


### PR DESCRIPTION
Delete Provider resource last so that others can still use the credentials during their deletion process

Signed-off-by: Muvaffak Onus <onus.muvaffak@gmail.com>